### PR TITLE
Repo rename: data-science-theory -> data-science-concepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p>
-    <h2 align="center">DATA SCIENCE THEORY</h2>
+    <h2 align="center">DATA SCIENCE CONCEPTS</h2>
     <h5 align="center">with examples</h5>
 </p>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 authors = ["Andrei Aksionov"]
-description = "Data science theory with examples"
+description = "Data science concepts with examples"
 license = "MIT"
-name = "data-science-theory"
+name = "data-science-concepts"
 version = "1.0.0"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
In the repo it's more about concepts with code examples, then about theory with formulas.